### PR TITLE
fix: setInterval not working

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,7 +169,7 @@ function getWebviewContent(gameCode: string) {
             map, bitmap, color, tune, setMap, addText, clearText, addSprite,
             getGrid, getTile, tilesWith, clearTile, setSolids, setPushables,
             setBackground, getFirst, getAll, width, height,setLegend, onInput,
-            afterInput, playTune, setTimeout, setInterval, clearTimeout, clearInterval
+            afterInput, playTune
           } = api
           // game starts here
           ${gameCode}


### PR DESCRIPTION
Fixed the issue where `setInterval` doesn't do anything. The web version of the Sprig engine doesn't export it since the browser has already implemented it.